### PR TITLE
fix lint errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,19 @@
+module.exports = {
+  root: true,
+  extends: 'airbnb/base',
+  // required to lint *.vue files
+  plugins: [
+    'html'
+  ],
+  // custom rules
+  'rules': {
+    // permit vuex state mutations
+    'no-param-reassign': ['error', { 'props': false }],
+    // permit functions to have unused parameters, e.g. for callbacks
+    'no-unused-vars': ['error', { 'args': 'none' }],
+    'quote-props': ['error', 'consistent-as-needed'],
+    'quotes': ['error', 'single', { 'allowTemplateLiterals': true }],
+    // allow debugger during development
+    'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0
+  }
+};

--- a/exercise_perseus_render/assets/src/vue/perseus.vue
+++ b/exercise_perseus_render/assets/src/vue/perseus.vue
@@ -457,7 +457,7 @@
     .paragraph
       padding: 4px
 
-    .svg-image *
-      padding-bottom: 0 !important
+    // .svg-image *
+    //   padding-bottom: 0 !important
 
 </style>

--- a/exercise_perseus_render/assets/src/vue/perseus.vue
+++ b/exercise_perseus_render/assets/src/vue/perseus.vue
@@ -407,56 +407,57 @@
 
 
 <style lang="stylus">
-// Use namespcesd unscoped styling here to alter Perseus' original styling in order to fit kolibri
 
-  #perseus img
-    width: 100%
-    height: 100%
-    max-width: 600px
-    padding: 10px
+  // Use namespaced unscoped styling here to alter Perseus' original styling in order to fit kolibri
+  #perseus
 
-  #perseus ul
-    border-bottom: 0
-    border-top: 0
+    img
+      width: 100%
+      height: 100%
+      max-width: 600px
+      padding: 10px
 
-  #perseus fieldset
-    border: none
+    ul
+      border-bottom: 0
+      border-top: 0
 
-  #perseus fieldset > ul
-    border: 1px solid #BABEC2
-    border-radius: 10px
-    padding: 0
+    fieldset
+      border: none
 
-  #perseus fieldset > ul > li
-    list-style-type: none
+    fieldset > ul
+      border: 1px solid #BABEC2
+      border-radius: 10px
+      padding: 0
 
-  #perseus .perseus-hint-renderer
-    color: #686868
-    padding: 6px 10px
-    font-weight: normal
+    fieldset > ul > li
+      list-style-type: none
 
-  #perseus .perseus-hint-renderer
-    margin-left: 40px
+    .perseus-hint-renderer
+      color: #686868
+      padding: 6px 10px
+      font-weight: normal
 
-  #perseus .perseus-hint-label
-    color: #686868
-    font-weight: 600
-    white-space: nowrap
-    right: 50px
-    position: relative
-    font-weight: bold
+    .perseus-hint-renderer
+      margin-left: 40px
 
-  #perseus .perseus-hint-label:before
-    content: '('
+    .perseus-hint-label
+      color: #686868
+      font-weight: 600
+      white-space: nowrap
+      right: 50px
+      position: relative
+      font-weight: bold
 
-  #perseus .perseus-hint-label:after
-    content: ')'
+    .perseus-hint-label:before
+      content: '('
 
-  #perseus .paragraph
-    padding: 4px
+    .perseus-hint-label:after
+      content: ')'
 
-  #perseus .svg-image *
-    padding-bottom: 0 !important
+    .paragraph
+      padding: 4px
 
+    .svg-image *
+      padding-bottom: 0 !important
 
 </style>


### PR DESCRIPTION

I missed the linter issues before merging https://github.com/learningequality/kolibri-exercise-perseus-plugin/pull/9 so submitting this as a quick fix.

Commented out the `*` and `!` selectors. If we add them back in, please add linter directives to skip the line, and comments explaining why they're necessary. thank you!
