### PR TITLE
include eslintrc.js file to avoid Parsing error: The keyword 'const' …

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,6 @@ include CONTRIBUTING.rst
 include CHANGELOG.rst
 include LICENSE
 include README.rst
-include requirements.txt
+include .eslintrc.js
 recursive-exclude exercise_perseus_render/* *pyc
 recursive-include exercise_perseus_render *


### PR DESCRIPTION
…is reserved