### PR TITLE
Large Text Render Fix

### DIFF
--- a/kolibri_exercise_perseus_plugin/assets/src/views/index.vue
+++ b/kolibri_exercise_perseus_plugin/assets/src/views/index.vue
@@ -357,8 +357,6 @@
     @import '../../../node_modules/perseus/lib/katex/katex.css'
     @import '../../../node_modules/perseus/build/perseus.css'
     require('css-loader?root=../../../node_modules/perseus/lib/mathquill!../../../node_modules/perseus/lib/mathquill/mathquill.css')
-
-  #perseus
     border-radius: $radius
     padding: 15px
     background-color: $core-bg-light
@@ -423,7 +421,6 @@
 
   // Use namespaced unscoped styling here to alter Perseus' original styling in order to fit kolibri
   #perseus
-
     img
       max-width: 100%
       padding: 10px
@@ -443,6 +440,12 @@
 
     fieldset > ul > li
       list-style-type: none
+
+    .graphie-container
+      position: absolute
+      height: 100%
+      width: 100%
+      top: 0
 
     .perseus-hint-renderer
       color: $core-text-annotation


### PR DESCRIPTION
Haven't tested extensively, so maybe considered WIP. Looks like there are some styles missing from the perseus plugin that would do us a lot of good. I actually went over to KA's site to see what we weren't getting.

Maybe fixes https://github.com/learningequality/kolibri/issues/1329