### PR TITLE
Improves the hint button's wording

### DIFF
--- a/kolibri_exercise_perseus_plugin/assets/src/views/index.vue
+++ b/kolibri_exercise_perseus_plugin/assets/src/views/index.vue
@@ -6,8 +6,8 @@
         <div id="workarea"></div>
       </div>
       <div v-if="anyHints">
-        <icon-button v-if="availableHints > 0" @click="takeHint" class="hint-btn" :text="$tr('hint')"></icon-button>
-        <icon-button v-else class="hint-btn" disabled :text="$tr('noMoreHint')"></icon-button>
+        <icon-button v-if="availableHints > 0" @click="takeHint" class="hint-btn" :text="$tr('hint', {hintsLeft: availableHints})"/>
+        <icon-button v-else class="hint-btn" disabled :text="$tr('noMoreHint')"/>
       </div>
       <div id="hintlabel" v-if="hinted">{{ $tr("hintLabel") }}</div>
       <div id="hintsarea"></div>
@@ -122,7 +122,7 @@
       showScratch: 'Show scratchpad',
       notAvailable: 'The scratchpad is not available',
       loading: 'Loading',
-      hint: 'Get a hint',
+      hint: 'Use a hint ({hintsLeft, number} left)',
       hintLabel: 'Hint:',
       noMoreHint: 'No more hints',
     },

--- a/kolibri_exercise_perseus_plugin/assets/src/views/index.vue
+++ b/kolibri_exercise_perseus_plugin/assets/src/views/index.vue
@@ -5,6 +5,10 @@
       <div id="problem-area">
         <div id="workarea"></div>
       </div>
+      <div v-if="anyHints">
+        <icon-button v-if="availableHints > 0" @click="takeHint" class="hint-btn" :text="$tr('hint')"></icon-button>
+        <icon-button v-else class="hint-btn" disabled :text="$tr('noMoreHint')"></icon-button>
+      </div>
       <div id="hintlabel" v-if="hinted">{{ $tr("hintLabel") }}</div>
       <div id="hintsarea"></div>
       <div style="clear: both;"></div>
@@ -16,10 +20,6 @@
       <div id="answer-area">
         <div class="info-box">
           <div id="solutionarea"></div>
-          <div v-if="anyHints">
-            <icon-button v-if="availableHints > 0" @click="takeHint" class="hint-btn" :text="$tr('hint')"></icon-button>
-            <icon-button v-else class="hint-btn" disabled :text="$tr('noMoreHint')"></icon-button>
-          </div>
         </div>
       </div>
     </div>
@@ -396,9 +396,8 @@
     border-top: 1px solid
 
   .hint-btn
-    float: right
-    padding-left: 16px
-    padding-right: 16px
+    margin-bottom: 1em
+    margin-left: 1em
 
   #solutionarea
     min-height: 35px


### PR DESCRIPTION
* Addresses the recommended changes mentioned in https://github.com/learningequality/kolibri/issues/1447
![hint](https://cloud.githubusercontent.com/assets/7193975/25818806/bdb20b64-33e0-11e7-93be-76df86f0f1f5.gif)


