### PR TITLE
Adds a randomized problemNumber to randomize answers in questions.

### DIFF
--- a/kolibri_exercise_perseus_plugin/assets/src/views/index.vue
+++ b/kolibri_exercise_perseus_plugin/assets/src/views/index.vue
@@ -139,10 +139,6 @@
         type: Number,
         default: 0,
       },
-      problemNumber: {
-        type: Number,
-        default: 1,
-      },
       defaultFile: {
         type: Object,
         required: true,
@@ -307,7 +303,7 @@
           item: this.item,
           workAreaSelector: '#workarea',
           problemAreaSelector: '#problem-area',
-          problemNum: this.problemNumber,
+          problemNum: Math.floor(Math.random() * 1000),
           enabledFeatures: {
             highlight: true,
             toolTipFormats: true,


### PR DESCRIPTION
Fixes https://github.com/learningequality/kolibri/issues/1445

Does this by making a random seed from 0 to 999 for the problemNum: https://github.com/Khan/perseus/blob/d3cf36dbabe1de61c8ba18f5f648ec3a513d2d02/src/item-renderer.jsx#L54

Which then gets used for shuffle operations for the radio question type: https://github.com/Khan/perseus/blob/d3cf36dbabe1de61c8ba18f5f648ec3a513d2d02/src/widgets/radio.jsx#L13