### PR TITLE
Applying mathquill styles properly

### DIFF
--- a/kolibri_exercise_perseus_plugin/assets/src/views/index.vue
+++ b/kolibri_exercise_perseus_plugin/assets/src/views/index.vue
@@ -352,7 +352,7 @@
     @import '../../../node_modules/perseus/stylesheets/local-only/khan-exercise.css'
     @import '../../../node_modules/perseus/lib/katex/katex.css'
     @import '../../../node_modules/perseus/build/perseus.css'
-    require('css-loader?root=../../../node_modules/perseus/lib/mathquill!../../../node_modules/perseus/lib/mathquill/mathquill.css')
+    @import '../../../node_modules/perseus/lib/mathquill/mathquill.css'
     border-radius: $radius
     padding: 15px
     background-color: $core-bg-light


### PR DESCRIPTION
stopped using a require, which was a workaround for webpack1
fixes https://github.com/learningequality/kolibri/issues/1512
@rtibbles was mostly the brain behind this