### PR TITLE
Bringing 'webpack' to existence in webpack config file.

### DIFF
--- a/kolibri_exercise_perseus_plugin/webpack.config.js
+++ b/kolibri_exercise_perseus_plugin/webpack.config.js
@@ -3,7 +3,7 @@
  * It will be bundled into the webpack configuration at build time.
  */
 var path = require('path');
-var webpack = require('webpack');
+var webpack = require('perseus/node_modules/webpack');
 
 module.exports = {
   resolve: {


### PR DESCRIPTION
Fixes #105 badly.

References perseus' webpack, though I think it'd be best for it to reference kolibri's webpack instance. Not sure about the best way to share that variable, though. Thoughts?