### PR TITLE
Add a top margin to the hint button

### DIFF
--- a/kolibri_exercise_perseus_plugin/assets/src/views/index.vue
+++ b/kolibri_exercise_perseus_plugin/assets/src/views/index.vue
@@ -486,4 +486,7 @@
     src: url(/static/fonts/Symbola.eot)
     src: local('Symbola Regular'), local('Symbola'), url(/static/fonts/Symbola.woff) format('woff'), url(/static/fonts/Symbola.ttf) format('truetype'), url(/static/fonts/Symbola.otf) format('opentype'), url(/static/fonts/Symbola.svg#Symbola) format('svg')
 
+  .hint-btn
+    margin-top: 32px
+
 </style>


### PR DESCRIPTION
* Add a top margin to the hint button
* Addresses https://github.com/learningequality/kolibri/issues/2289

![127 0 0 1-8000-learn-](https://user-images.githubusercontent.com/7193975/31030337-cf33351c-a509-11e7-9181-9726e32545a6.png)
