### PR TITLE
Provide React to fix Grapher Questions

### DIFF
--- a/kolibri_exercise_perseus_plugin/webpack.config.js
+++ b/kolibri_exercise_perseus_plugin/webpack.config.js
@@ -111,6 +111,7 @@ module.exports = {
       Khan: 'KAGlobals/Khan',
       i18n: 'KAGlobals/i18n',
       $_: 'KAGlobals/$_',
+      React: 'react',
     }),
   ],
   // Parse the path of the perseus node_modules directory into our build machinery,


### PR DESCRIPTION
Grapher questions are currently broken, because of a reference to a `React` global variable.

My rage knows no bounds.

This adds React to webpack provide plugin to fix this.