### PR TITLE
Fix numberline

### DIFF
--- a/kolibri_exercise_perseus_plugin/assets/src/views/index.vue
+++ b/kolibri_exercise_perseus_plugin/assets/src/views/index.vue
@@ -7,7 +7,6 @@
           <ui-progress-linear v-show="loading" />
         </div>
         <div
-          v-show="!loading"
           :dir="dir"
           id="problem-area"
         >


### PR DESCRIPTION
Remove v-show on problem-area that was causing issues for raphael svg centering.