### PR TITLE
Blur inputs after setting the correct answer.

### DIFF
--- a/kolibri_exercise_perseus_plugin/assets/src/widgetSolver/index.js
+++ b/kolibri_exercise_perseus_plugin/assets/src/widgetSolver/index.js
@@ -52,6 +52,9 @@ export default (widget, type, rubric) => {
   }
   try {
     widgetSolvers[type](widget, rubric);
+    const blurWidget = widget.blurInputPath;
+    // Call blurWidget with an empty path
+    blurWidget && blurWidget('');
   } catch (e) {
     logging.debug('An error occurred while solving a problem', e);
   }


### PR DESCRIPTION
Before:
![shown_keypad](https://user-images.githubusercontent.com/1680573/53585889-d427d400-3b3b-11e9-8b42-21ba2d6825b2.gif)

After:
![hide_keyboard_correct_answer](https://user-images.githubusercontent.com/1680573/53585905-db4ee200-3b3b-11e9-9b4b-3ad6bd67e2f5.gif)

Fixes #153 and closes #183